### PR TITLE
feat: add interactive agent file selection to create-rnvibecode CLI

### DIFF
--- a/packages/starter-kit/package.json
+++ b/packages/starter-kit/package.json
@@ -19,6 +19,7 @@
     "name": "create-rnvibecode"
   },
   "dependencies": {
+    "@inquirer/select": "^4.0.2",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "degit": "^2.8.4",


### PR DESCRIPTION
Closes #5

Adds an interactive select prompt when running `npx create-rnvibecode` that lets users choose which AI agent instruction file(s) to generate: CLAUDE.md (Anthropic), AGENTS.md (cross-provider standard), GEMINI.md (Google Gemini), all three, or none.

Also adds a non-interactive `--agent <choice>` flag for scripted/CI usage.

Generated with [Claude Code](https://claude.ai/code)